### PR TITLE
init log kit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,10 @@ require (
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1 // indirect
 	go.uber.org/atomic v1.7.0
+	go.uber.org/zap v1.19.0
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 	google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368 // indirect
 	google.golang.org/grpc v1.40.0

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,33 @@
+package log
+
+import (
+	"context"
+)
+
+func init() {
+	defaultLog = New(nil)
+}
+
+var defaultLog = New(NewOptions())
+
+func FromContext(ctx context.Context) *ZapLogger {
+	if ctx != nil {
+		logger := ctx.Value("log")
+		if logger != nil {
+			return logger.(*ZapLogger)
+		}
+	}
+	return WithName("Unknown-Context")
+}
+
+func Info(msg string, keysAndValues ...interface{}) {
+	defaultLog.Info(msg, keysAndValues...)
+}
+
+func Infof(format string, args ...interface{}) {
+	defaultLog.Infof(format, args...)
+}
+
+func InfoC(ctx context.Context, msg string, keysAndValues ...interface{}) {
+	defaultLog.InfoC(ctx, msg, keysAndValues...)
+}

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,0 +1,28 @@
+package log_test
+
+import (
+	"github.com/opensergo/opensergo-control-plane/pkg/log"
+	"testing"
+)
+
+func Test_WithName(t *testing.T) {
+	defer log.Flush()
+
+	newLogger := log.WithName("test")
+	newLogger.Info("test")
+}
+
+func Test_WithValues(t *testing.T) {
+	defer log.Flush()
+
+	newLogger := log.WithValues("key", "value")
+	newLogger.Info("test")
+}
+
+func Test_Info(t *testing.T) {
+	defer log.Flush()
+
+	log.Info("test")
+	log.Info("test", "key", "value")
+	log.Infof("test: %s", "format")
+}

--- a/pkg/log/options.go
+++ b/pkg/log/options.go
@@ -1,0 +1,102 @@
+package log
+
+import (
+	"fmt"
+	"github.com/spf13/pflag"
+	"go.uber.org/zap/zapcore"
+	"strings"
+	"time"
+)
+
+const (
+	consoleFormat = "console"
+	jsonFormat    = "json"
+
+	flagName              = "log.name"
+	flagOutputPaths       = "log.output-paths"
+	flagErrorOutputPaths  = "log.error-output-paths"
+	flagLevel             = "log.level"
+	flagFormat            = "log.format"
+	flagDisableCaller     = "log.disable-caller"
+	flagDisableStacktrace = "log.disable-stacktrace"
+	flagEnableColor       = "log.enable-color"
+)
+
+type Options struct {
+	Name              string   `json:"name"               mapstructure:"name"`
+	OutputPaths       []string `json:"output-paths"       mapstructure:"output-paths"`
+	ErrorOutputPaths  []string `json:"error-output-paths" mapstructure:"error-output-paths"`
+	Level             string   `json:"level"              mapstructure:"level"`
+	Format            string   `json:"format"             mapstructure:"format"`
+	DisableCaller     bool     `json:"disable-caller"     mapstructure:"disable-caller"`
+	DisableStacktrace bool     `json:"disable-stacktrace" mapstructure:"disable-stacktrace"`
+	EnableColor       bool     `json:"enable-color"       mapstructure:"enable-color"`
+}
+
+func NewOptions(opts ...Option) *Options {
+	result := Options{
+		OutputPaths:       []string{"stdout"},
+		ErrorOutputPaths:  []string{"stderr"},
+		Level:             zapcore.InfoLevel.String(),
+		Format:            consoleFormat,
+		DisableCaller:     false,
+		DisableStacktrace: false,
+		EnableColor:       false,
+	}
+
+	for _, opt := range opts {
+		opt(&result)
+	}
+
+	return &result
+}
+
+type Option func(o *Options)
+
+func WithFormat(s string) Option {
+	return func(o *Options) {
+		o.Format = s
+	}
+}
+
+func WithLevel(s string) Option {
+	return func(o *Options) {
+		o.Level = s
+	}
+}
+
+func (o *Options) Validate() []error {
+	var errs []error
+
+	var zapLevel zapcore.Level
+	if err := zapLevel.UnmarshalText([]byte(o.Level)); err != nil {
+		errs = append(errs, err)
+	}
+
+	format := strings.ToLower(o.Format)
+	if format != consoleFormat && format != jsonFormat {
+		errs = append(errs, fmt.Errorf("unrecognized format: %q", o.Format))
+	}
+
+	return errs
+}
+
+func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.Name, flagName, o.Name, "The name of the logger.")
+	fs.StringSliceVar(&o.OutputPaths, flagOutputPaths, o.OutputPaths, "Output paths of log.")
+	fs.StringSliceVar(&o.ErrorOutputPaths, flagErrorOutputPaths, o.ErrorOutputPaths, "Error output paths of log.")
+	fs.StringVar(&o.Level, flagLevel, o.Level, "Minimum log output `LEVEL`.")
+	fs.BoolVar(&o.DisableCaller, flagDisableCaller, o.DisableCaller, "Disable output of caller information in the log.")
+	fs.BoolVar(&o.DisableStacktrace, flagDisableStacktrace, o.DisableStacktrace, "Disable the log to record a stack trace "+
+		"for all messages at or above panic level.")
+	fs.StringVar(&o.Format, flagFormat, o.Format, "Log output `FORMAT`, support console or json format.")
+	fs.BoolVar(&o.EnableColor, flagEnableColor, o.EnableColor, "Enable output ansi colors in console format logs.")
+}
+
+func timeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+	enc.AppendString(t.Format("2022-12-01 18:00:00.000"))
+}
+
+func milliSecondsDurationEncoder(d time.Duration, enc zapcore.PrimitiveArrayEncoder) {
+	enc.AppendFloat64(float64(d) / float64(time.Millisecond))
+}

--- a/pkg/log/options_test.go
+++ b/pkg/log/options_test.go
@@ -1,0 +1,32 @@
+package log_test
+
+import (
+	"fmt"
+	"github.com/opensergo/opensergo-control-plane/pkg/log"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_Options_AddFlags(t *testing.T) {
+	opts := log.NewOptions()
+	fs := pflag.NewFlagSet("test", pflag.ExitOnError)
+	opts.AddFlags(fs)
+
+	args := []string{"--log.level=debug"}
+	err := fs.Parse(args)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "debug", opts.Level)
+}
+
+func Test_Options_Validate(t *testing.T) {
+	opts := log.NewOptions(log.WithFormat("test"), log.WithLevel("test"))
+	errs := opts.Validate()
+	expected := `[unrecognized level: "test" unrecognized format: "test"]`
+	assert.Equal(t, expected, fmt.Sprintf("%s", errs))
+
+	opts = log.NewOptions()
+	errs = opts.Validate()
+	assert.Equal(t, []error(nil), errs)
+}

--- a/pkg/log/zaplog.go
+++ b/pkg/log/zaplog.go
@@ -1,0 +1,163 @@
+package log
+
+import (
+	"context"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// ZapLogger is a thin wrapper for zap.Logger that adds Ctx method
+type ZapLogger struct {
+	*zap.Logger
+}
+
+func New(o *Options) *ZapLogger {
+	if o == nil {
+		o = NewOptions()
+	}
+
+	var zapLevel zapcore.Level
+	if err := zapLevel.UnmarshalText([]byte(o.Level)); err != nil {
+		zapLevel = zapcore.InfoLevel
+	}
+	encodeLevel := zapcore.CapitalLevelEncoder
+	if o.Format == consoleFormat && o.EnableColor {
+		encodeLevel = zapcore.CapitalColorLevelEncoder
+	}
+
+	cfg := &zap.Config{
+		Level:             zap.NewAtomicLevelAt(zapLevel),
+		Development:       false,
+		DisableCaller:     o.DisableCaller,
+		DisableStacktrace: o.DisableStacktrace,
+		Sampling: &zap.SamplingConfig{
+			Initial:    100,
+			Thereafter: 100,
+		},
+		Encoding: o.Format,
+		EncoderConfig: zapcore.EncoderConfig{
+			MessageKey: "msg",
+			LevelKey:   "level",
+			TimeKey:    "timestamp",
+			NameKey:    "logger",
+			CallerKey:  "caller",
+			//FunctionKey:    "func", // if need
+			StacktraceKey:  "stacktrace",
+			LineEnding:     zapcore.DefaultLineEnding,
+			EncodeLevel:    encodeLevel,
+			EncodeTime:     timeEncoder,
+			EncodeDuration: milliSecondsDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+			//EncodeName:       zapcore.FullNameEncoder,
+			//ConsoleSeparator: "",
+		},
+		OutputPaths:      o.OutputPaths,
+		ErrorOutputPaths: o.ErrorOutputPaths,
+		//InitialFields:    nil,
+	}
+	logger, err := cfg.Build(zap.AddStacktrace(zapcore.PanicLevel))
+	if err != nil {
+		panic(err)
+	}
+	//logger = logger.Named(o.Name)
+
+	//zap.RedirectStdLog(logger.Named(o.Name))
+	//zap.ReplaceGlobals(logger)
+
+	return &ZapLogger{
+		Logger: logger,
+	}
+}
+
+// Flush calls the underlying Core's Sync method, flushing any buffered log
+// entries. Applications should take care to call Sync before exiting.
+func Flush() error {
+	return defaultLog.Sync()
+}
+
+func WithName(s string) *ZapLogger {
+	return defaultLog.WithName(s)
+}
+
+// WithName adds a new path segment to the logger's name. Segments are joined by
+// periods. By default, Loggers are unnamed.
+func (zl *ZapLogger) WithName(name string) *ZapLogger {
+	return &ZapLogger{
+		zl.Named(name),
+	}
+}
+
+func WithValues(keysAndValues ...interface{}) *ZapLogger {
+	return defaultLog.WithValues(keysAndValues...)
+}
+
+func (zl *ZapLogger) WithValues(keysAndValues ...interface{}) *ZapLogger {
+	return &ZapLogger{
+		zl.With(zl.handleFields(keysAndValues)...),
+	}
+}
+
+func (zl *ZapLogger) Info(msg string, keysAndValues ...interface{}) {
+	zl.Logger.Info(msg, zl.handleFields(keysAndValues)...)
+}
+
+func (zl *ZapLogger) Infof(format string, args ...interface{}) {
+	zl.Logger.Sugar().Infof(format, args...)
+}
+
+func (zl *ZapLogger) InfoC(ctx context.Context, msg string, keysAndValues ...interface{}) {
+	// todo
+	//keysAndValues = zl.FromBizContext(ctx, keysAndValues...)
+	zl.Logger.Info(msg, zl.handleFields(keysAndValues)...)
+}
+
+func (zl *ZapLogger) WithContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, "log", zl)
+}
+
+// handleFields converts a bunch of arbitrary key-value pairs into Zap fields.  It takes
+// additional pre-converted Zap fields, for use with automatically attached fields, like
+// `error`.
+func (zl *ZapLogger) handleFields(args []interface{}) []zap.Field {
+	// a slightly modified version of zap.SugaredLogger.sweetenFields
+	if len(args) == 0 {
+		// Slightly slower fast path when we need to inject "v".
+		return []zap.Field{}
+	}
+
+	// unlike Zap, we can be pretty sure users aren't passing structured
+	// fields (since logr has no concept of that), so guess that we need a
+	// little less space.
+	fields := make([]zap.Field, 0, len(args)/2)
+	for i := 0; i < len(args); {
+		// Check just in case for strongly-typed Zap fields,
+		// which might be illegal (since it breaks
+		// implementation agnosticism). If disabled, we can
+		// give a better error message.
+		if _, ok := args[i].(zap.Field); ok {
+			zl.WithOptions(zap.AddCallerSkip(1)).DPanic("strongly-typed Zap Field passed to logr", zap.Any("zap field", args[i]))
+			break
+		}
+
+		// make sure this isn't a mismatched key
+		if i == len(args)-1 {
+			zl.WithOptions(zap.AddCallerSkip(1)).DPanic("odd number of arguments passed as key-value pairs for logging", zap.Any("ignored key", args[i]))
+			break
+		}
+
+		// process a key-value pair,
+		// ensuring that the key is a string
+		key, val := args[i], args[i+1]
+		keyStr, isString := key.(string)
+		if !isString {
+			// if the key isn't a string, DPanic and stop logging
+			zl.WithOptions(zap.AddCallerSkip(1)).DPanic("non-string key argument passed to logging, ignoring all later arguments", zap.Any("invalid key", key))
+			break
+		}
+
+		fields = append(fields, zap.Any(keyStr, val))
+		i += 2
+	}
+
+	return append(fields)
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://opensergo.io/docs/community/contribution-guidance/
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Add fundamental logger mechanism

### Does this pull request fix one issue?
#16 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
### 需求

目前 OpenSergo 控制面的日志机制非常简单，复用了 Sentinel Go 的日志模块。我们需要设计一个通用的 logger 机制与基本实现，并支持任意扩展。

#### 功能分析

1. 满足log基本功能

- 日志级别，debug，info，warn，error，panic，fatal
- 打印方式，console 或 json
- 支持日志压缩，切割等
- hook 支持

2. 既提供全局默认log，也支持自定义传参
3. 兼容标准库中的log
4. 带 keyandvalues 的 log
5. 兼容zap，logrus，klog，grpc 等log
6. otel 支持，即带 context log
7. 动态更改日志级别
8. console 中支持颜色显示
9. error 等级别支持发送到监控系统或触发报警
10. 高性能

### 概要设计

基于zap封装，达到高性能（更少的内存分配及非sugar log 未使用反射）

1. 定义日志选项

2. 创建全局logger及各级别打印方法
3. 写入到支持的输出设备中

### 参考

https://pkg.go.dev/golang.org/x/exp/slog

https://github.com/uber-go/zap

https://github.com/golang/glog

https://github.com/istio/klog

https://github.com/go-logr/logr

https://github.com/go-kratos/kratos

https://github.com/zeromicro/go-zero

### Describe how to verify it
reference unit test

### Special notes for reviews