### PR TITLE
add skip-dirs in golangci-lint

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -30,7 +30,7 @@ jobs:
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
 
       - name: Run Linter
-        run: golangci-lint run --timeout=10m -v --disable-all --enable=govet --enable=staticcheck --enable=ineffassign --enable=misspell
+        run: golangci-lint run --skip-dirs=pkg/api,pkg/proto --timeout=10m -v --disable-all --enable=govet --enable=staticcheck --enable=ineffassign --enable=misspell
 
       - name: Test
         run: |


### PR DESCRIPTION
Signed-off-by: Jiangnan Jia <jnan0806@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://opensergo.io/docs/community/contribution-guidance/
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
add skip-dirs in golangci-lint command to avoid exec golangci-lint in the unnecessary dirs. like : `pkg/api` `pkg/proto`

<img width="1586" alt="image" src="https://user-images.githubusercontent.com/43714056/208295757-02606edd-3eea-481b-9a83-5ca07981961a.png">


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews